### PR TITLE
Template grammar corrections

### DIFF
--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -33,7 +33,7 @@ type Context interface {
 
 {{#panel title="Context and Rendering"}}
 
-As part of the context interface is a `Render` function that takes a type of `render.Renderer`, see [rendering](/docs/rendering) for more information.
+As part of the context interface, there is a `Render` function that takes a type of `render.Renderer`. See [rendering](/docs/rendering) for more information.
 
 Any values that are "set" on the context will automatically be available to the `render.Renderer` that is passed into the `Render` function.
 

--- a/templates/docs/middleware.md
+++ b/templates/docs/middleware.md
@@ -1,6 +1,6 @@
 # Middleware
 
-Middleware allows for the interjection of code in the request/response cycle. Common use cases for middleware are things like logging (which Buffalo already does), authentication requests, etc... Buffalo does ship with a selection of already written middleware, please checkout out [https://godoc.org/github.com/gobuffalo/buffalo/middleware](https://godoc.org/github.com/gobuffalo/buffalo/middleware) for details on those.
+Middleware allows for the interjection of code in the request/response cycle. Common use cases for middleware are things like logging (which Buffalo already does), authentication requests, etc. Buffalo ships with some common middleware, so please checkout out [https://godoc.org/github.com/gobuffalo/buffalo/middleware](https://godoc.org/github.com/gobuffalo/buffalo/middleware) for details on those.
 
 {{ partial "topics.html" }}
 

--- a/templates/docs/routing.md
+++ b/templates/docs/routing.md
@@ -20,7 +20,7 @@ a := buffalo.Automatic(buffalo.Options{})
 a := buffalo.New(buffalo.Options{})
 ```
 
-It is highly recommend to use `buffalo.Automatic` to create your application. The `Automatic` command will configure your new application with a variety of settings and functionality that we believe we be useful to 90% of all web applications. If you want "complete" control over your application, then just create a `New` Buffalo app.
+It is highly recommended to use `buffalo.Automatic` to create your application. The `Automatic` command will configure your new application with a variety of settings and functionality that we believe are useful to 90% of all web applications. If you want "complete" control over your application, then just create a `New` Buffalo app.
 {{/panel}}
 
 {{#panel title="Mapping Handlers"}}


### PR DESCRIPTION
Made a couple of typo/grammar corrections.  Also split up large sentence in the middleware doc for better readability.