### PR TITLE
Correct minor errors in markdown templates.

### DIFF
--- a/templates/docs/custom-helpers.md
+++ b/templates/docs/custom-helpers.md
@@ -8,7 +8,7 @@ No templating package would be complete without allowing for you to build your o
 
 {{#panel title="Return Values"}}
 
-The first thing to understand about building custom helper functions is their are a few "valid" return values:
+The first thing to understand about building custom helper functions is there are a few "valid" return values:
 
 #### `string`
 
@@ -57,7 +57,7 @@ func() ( template.HTML, error ) {
 
 {{#panel title="Input Values"}}
 
-Custom helper functions can take any type, and any number of arguments. There is an option last argument, [`velvet.HelperContext`](https://godoc.org/github.com/gobuffalo/velvet#HelperContext), that can be received. It's quite useful, and I would recommend taking it, as it provides you access to things like the context of the call, the block associated with the helper, etc...
+Custom helper functions can take any type, and any number of arguments. There is an optional last argument, [`velvet.HelperContext`](https://godoc.org/github.com/gobuffalo/velvet#HelperContext), that can be received. It's quite useful, and I would recommend taking it, as it provides you access to things like the context of the call, the block associated with the helper, etc...
 
 {{/panel}}
 

--- a/templates/docs/errors.md
+++ b/templates/docs/errors.md
@@ -23,7 +23,7 @@ func MyHandler(c buffalo.Context) error {
 
 {{#panel title="Default Error Handling (Development)" name="dev-error-handling"}}
 
-In "development" mode (`GO_ENV=development`), Buffalo, will generate some helpful errors pages for you.
+In "development" mode (`GO_ENV=development`), Buffalo will generate some helpful errors pages for you.
 
 <table width="100%">
 <tr>
@@ -36,12 +36,12 @@ In "development" mode (`GO_ENV=development`), Buffalo, will generate some helpfu
 </tr>
 </table>
 
-In "production" mode (`GO_ENV=production`), Buffalo, will not generate pages that have developer style information, instead the pages are simpler.
+In "production" mode (`GO_ENV=production`), Buffalo will not generate pages that have developer style information. Instead the pages are simpler.
 {{/panel}}
 
 {{#panel title="Custom Error Handling"}}
 
-While Buffalo, out of the box, will handle errors for you, it can be useful to handle errors in a custom way. To accomplish this, Buffalo, allows for the mapping of HTTP status codes to specific handlers, so the error can be dealt with in a custom fashion.
+While Buffalo will handle errors for you out of the box, it can be useful to handle errors in a custom way. To accomplish this, Buffalo allows for the mapping of HTTP status codes to specific handlers. This means the error can be dealt with in a custom fashion.
 
 ```go
 app = buffalo.Automatic(buffalo.Options{
@@ -62,6 +62,6 @@ func MyHandler(c buffalo.Context) error {
 }
 ```
 
-In the above example any error from you application that returns a status of `422` will be caught by the custom handler and will be dealt with accordingly.
+In the above example any error from your application that returns a status of `422` will be caught by the custom handler and will be dealt with accordingly.
 
 {{/panel}}

--- a/templates/docs/helpers.md
+++ b/templates/docs/helpers.md
@@ -7,7 +7,7 @@
 
 {{#panel title="Each Statements (Array)" name="each-array"}}
 
-When looping through `arrays` or `slices`, the block being looped through will be access to the "global" context, as well as have four new variables available within that block:
+When looping through `arrays` or `slices`, the block being looped through will have access to the "global" context, as well as have four new variables available within that block:
 
 * `@first` [`bool`] - is this the first pass through the iteration?
 * `@last` [`bool`] - is this the last pass through the iteration?

--- a/templates/docs/layouts.md
+++ b/templates/docs/layouts.md
@@ -6,7 +6,7 @@
 
 {{#panel title="Using a Standard Layout" name="standard"}}
 
-It is quite common to want to use the same layout across most, if not, all of an application. When creating a new `render.Engine` the `HTMLLayout` property can be set to a file that will automatically be used by the `render.HTML` function.
+It is quite common to want to use the same layout across most, if not all of an application. When creating a new `render.Engine` the `HTMLLayout` property can be set to a file that will automatically be used by the `render.HTML` function.
 
 ```go
 var r *render.Engine

--- a/templates/docs/partials.md
+++ b/templates/docs/partials.md
@@ -5,7 +5,7 @@
 {{ partial "topics.html" }}
 
 {{#panel title="Naming"}}
-All partial file names must start with an `_`. For example: `_form.html`. This helps to different partials from other view templates in your application.
+All partial file names must start with an `_`. For example: `_form.html`. This helps to differentiate partials from other view templates in your application.
 
 **templates/users/new.html**
 ```html
@@ -33,7 +33,7 @@ All partial file names must start with an `_`. For example: `_form.html`. This h
 
 {{#panel title="Context"}}
 
-All [rendering context](/docs/rendering) from parent template will automatically pass through to the partial, and any partials that partial may call. (see also [context](/docs/context))
+All [rendering context](/docs/rendering) from the parent template will automatically pass through to the partial, and any partials that partial may call. (see also [context](/docs/context))
 
 **actions/users.go**
 ```html

--- a/templates/docs/rendering.md
+++ b/templates/docs/rendering.md
@@ -27,7 +27,7 @@ Thankfully the [https://github.com/gobuffalo/buffalo/render](https://github.com/
 
 {{#panel title="Creating a Render Engine"}}
 
-A render engine is used to store information about configuration needed for rendering. Examples include: [helpers](/docs/helpers), [layouts](/docs/layouts), etc... Multiple engines can be initialized. For example one engine for the "main" site, and another for the "admin" portion.
+A render engine is used to store information about configuration needed for rendering. Examples include: [helpers](/docs/helpers), [layouts](/docs/layouts), etc. Multiple engines can be initialized. For example one engine for the "main" site, and another for the "admin" portion.
 
 By default an initial render engine is created for the application during application generation:
 
@@ -51,7 +51,7 @@ func init() {
 
 {{#panel title="Markdown"}}
 
-Files passed into the `render.HTML` or `render.Template` functions, that have an extension of `.md`, will be converted from Markdown (using GitHub flavored Markdown) to HTML before being run through the templating engine. This makes for incredibly easy templating for simplier pages.
+Files passed into the `render.HTML` or `render.Template` functions, that have an extension of `.md`, will be converted from Markdown (using GitHub flavored Markdown) to HTML before being run through the templating engine. This makes for incredibly easy templating for simpler pages.
 
 ```markdown
 <!-- beatles.md -->

--- a/templates/docs/templating.md
+++ b/templates/docs/templating.md
@@ -47,7 +47,7 @@ Which would result in the following output:
 
 {{#panel title="If Statements" name="if"}}
 
-What to do? Should you render the content, or not? Using Velvet's built in `if`, `else`, and `unless` helpers, let you figure it out for yourself.
+What to do? Should you render the content, or not? Using Velvet's built in `if`, `else`, and `unless` helpers let you figure it out for yourself.
 
 ```handlebars
 \{{#if true }}


### PR DESCRIPTION
Spelling and/or grammar corrections for readability and correctness.