### PR TITLE
Simple update to Getting-Started

### DIFF
--- a/templates/docs/getting-started.md
+++ b/templates/docs/getting-started.md
@@ -40,7 +40,7 @@ Buffalo aims to make building new web applications in Go as simple as possible, 
 $ buffalo new <name>
 ```
 
-That will generate a whole new Buffalo application that is ready to go. It'll even run `go get` for you to make sure you have all of the necessary dependencies needed to run your application.
+That will generate a whole new Buffalo application that is ready to go. It'll even run `go get` for you to make sure you have all of the necessary dependencies needed to run your application. 
 
 ```text
 $ buffalo new coke
@@ -85,6 +85,12 @@ To see a list of available flags for the `new` command, just check out its help.
 
 ```
 $ buffalo help new
+```
+
+Note: by default, Buffalo generates a database.yml targeted for postgres. If you wish to change this behavior, you can pass in a `--db-type` flag into the `new` command.
+
+```
+$ buffalo new coke --db-type sqlite3
 ```
 
 {{/panel}}


### PR DESCRIPTION
Taking feedback from https://github.com/gobuffalo/buffalo/issues/135, improve getting-started guide in regards to the default database when starting the local dev server. 