### PR TITLE
Break up sentence in _dev.md template to remove typo and improve readability

### DIFF
--- a/templates/docs/_dev.md
+++ b/templates/docs/_dev.md
@@ -8,7 +8,7 @@ One of the downsides to Go development is the lack of code "reloading". This mea
 $ buffalo dev
 ```
 
-The `dev` command will watch your `.go` and `.html` files by default and rebuild, and restart, your binary for you so you don't have to worry about such things. The `dev` command will also watch [asset](/docs/assets) and recompile those as well.
+The `dev` command will watch your `.go` and `.html` files by default. It will rebuild and restart your binary for you so you don't have to worry about such things. The `dev` command will also watch [asset](/docs/assets) and recompile those as well.
 
 Just run the `buffalo dev` command and start coding.
 


### PR DESCRIPTION
Just a quick fix to help the readers sail through this splendid documentation.