### PR TITLE
Added basic README and clarified starting in your $GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# gobuffalo
+This is the repository for http://www.gobuffalo.io
+
+Contributing to this documentation site is a great, and easy, way to help make Buffalo better! 

--- a/templates/docs/getting-started.md
+++ b/templates/docs/getting-started.md
@@ -35,9 +35,10 @@ $ go get -u github.com/gobuffalo/buffalo/buffalo
 
 {{#panel title="Generating a New Project" name="new-project"}}
 
-Buffalo aims to make building new web applications in Go as simple as possible, and what could be more simple that a new application generator?
+Buffalo aims to make building new web applications in Go as quick and simple as possible, and what could be more simple than a *new application* generator? Start by going to your `$GOPATH` and create your new application!
 
 ```
+$ cd $GOPATH/src/github.com/$USER/
 $ buffalo new <name>
 ```
 


### PR DESCRIPTION
Even the documentation repo should have a basic README.

I totally missed that you have to stand in your $GOPATH to get a working generated project, and I saw in the slack chat that I was not the only one. Hopefully this addition can make that clear. 