### PR TITLE
changed Params to Param where appropriate

### DIFF
--- a/templates/docs/routing.md
+++ b/templates/docs/routing.md
@@ -78,7 +78,7 @@ Since Buffalo is the [http://www.gorillatoolkit.org/pkg/mux](http://www.gorillat
 
 ```go
 a.GET("/users/{name}", func (c buffalo.Context) error {
-  return c.Render(200, render.String(c.Params("name")))
+  return c.Render(200, render.String(c.Param("name")))
 })
 // etc...
 ```
@@ -90,7 +90,7 @@ a.GET("/users/new", func (c buffalo.Context) error {
   return c.Render(200, render.String("new"))
 })
 a.GET("/users/{name}", func (c buffalo.Context) error {
-  return c.Render(200, render.String(c.Params("name")))
+  return c.Render(200, render.String(c.Param("name")))
 })
 // etc...
 ```


### PR DESCRIPTION
After copying the original code from the docs, my app wouldn't compile.  It looks like `Params` was used in a few places where `Param` should have been