### PR TITLE
Remove broken two-column layout for code samples

### DIFF
--- a/templates/docs/generators/_resource.md
+++ b/templates/docs/generators/_resource.md
@@ -20,9 +20,6 @@ $ buffalo g resource users
 --> goimports -w .
 ```
 
-<table width="100%">
-<tr>
-<td width="50%" valign="top">
 ```go
 // actions/users.go
 package actions
@@ -72,8 +69,7 @@ func (v *UsersResource) Destroy(c buffalo.Context) error {
 	return c.Render(200, r.String("Users#Destroy"))
 }
 ```
-</td>
-<td width="50%" valign="top">
+
 ```go
 // actions/users_test.go
 package actions_test
@@ -119,8 +115,5 @@ func Test_UsersResource_Destroy(t *testing.T) {
 	r.Fail("Not Implemented!")
 }
 ```
-</td>
-</tr>
-</table>
 
 <% } %>


### PR DESCRIPTION
The markdown doesn't get converted to code layout when surrounded by `<table>` tags. 

<img width="1157" alt="screen shot 2017-03-12 at 21 25 28" src="https://cloud.githubusercontent.com/assets/50456/23841507/10fd4ba0-076b-11e7-93c6-c0bbf2d6173c.png">
