### PR TITLE
Make sure the user will have a correct $PATH

### DIFF
--- a/templates/docs/getting-started.md
+++ b/templates/docs/getting-started.md
@@ -12,6 +12,7 @@ Buffalo aims to make building new web applications in Go as quick and simple as 
 
 <%= code("text") { %>
 $ cd $GOPATH/src/github.com/$USER/
+$ # Make sure $GOPATH/bin is in your $PATH, then:
 $ buffalo new <name>
 <% } %>
 


### PR DESCRIPTION
If the $PATH doesn't contain `$GOPATH/bin`, `buffalo` command is not available.