### PR TITLE
Minor updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,6 +57,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/gobuffalo/gobuffalo"
+  packages = ["actions","actions/helpers"]
+  revision = "c42035e390d76e52c55c4a9df03d06829ea45e3a"
+
+[[projects]]
+  branch = "master"
   name = "github.com/gobuffalo/packr"
   packages = ["."]
   revision = "9d3b78bfcb56d490ba2cae05965890154f04f6f1"
@@ -346,6 +352,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ec869b9d44ce87026b93ba8e42355e74f9cb1b484b9a18d28c0936d92c1bc641"
+  inputs-digest = "25b42bea69185c9a37a65fc027517d35ec0f6e64e703a9d1f1607602ae37dc7b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/actions/home_test.go
+++ b/actions/home_test.go
@@ -14,5 +14,5 @@ func Test_HomeHandler(t *testing.T) {
 	w := willie.New(actions.App())
 	res := w.Request("/").Get()
 
-	r.Equal(200, res.Code)
+	r.Equal(302, res.Code)
 }


### PR DESCRIPTION
- Update Gopkg.lock (auto generated from `buffalo setup`).
- Update home_test.go to reflect correct status code being returned.