### PR TITLE
When fetching packages with go get, remove redundant go install

### DIFF
--- a/templates/docs/getting-started.md
+++ b/templates/docs/getting-started.md
@@ -14,10 +14,7 @@ Before installing make sure you have the required dependencies installed:
 These instructions can also be used for upgrading to a newer version of Buffalo.
 
 ```bash
-# download the libraries
 $ go get -u -v github.com/gobuffalo/buffalo/...
-# install the binary
-$ go install -v github.com/gobuffalo/buffalo/buffalo
 ```
 
 <%= title("Generating a New Project") %>

--- a/templates/docs/getting-started/_new.md
+++ b/templates/docs/getting-started/_new.md
@@ -3,11 +3,8 @@ $ buffalo new coke
 Buffalo version <%= version %>
 
 --> go get -u golang.org/x/tools/cmd/goimports
---> go install golang.org/x/tools/cmd/goimports
 --> go get -u github.com/golang/dep/cmd/dep
---> go install github.com/golang/dep/cmd/dep
 --> go get -u github.com/motemen/gore
---> go install github.com/motemen/gore
 --> /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/README.md
 --> /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/actions/actions_test.go
 --> /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/actions/app.go
@@ -34,7 +31,6 @@ Buffalo version <%= version %>
 --> /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/models/models_test.go
 --> /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/grifts/db.go
 --> go get github.com/markbates/pop/...
---> go install github.com/markbates/pop/soda
 --> database.yml
 --> /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/Dockerfile
 --> /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/.dockerignore


### PR DESCRIPTION
"go get" fetches and installs the specified package according to the
documentation:

    Get downloads the packages named by the import paths, along with their
    dependencies. It then installs the named packages, like 'go install'.

Testing this myself on go1.8.3 and go1.9rc2 having an older version of
buffalo binary install, then running:

    go get -u github.com/gobuffalo/buffalo/...

Shows the binary is also updated successfully when checking the version.