### PR TITLE
Update getting-started.md

### DIFF
--- a/templates/docs/getting-started.md
+++ b/templates/docs/getting-started.md
@@ -15,6 +15,7 @@ These instructions can also be used for upgrading to a newer version of Buffalo.
 
 ```bash
 $ go get -u -v github.com/gobuffalo/buffalo/...
+$ go install -v github.com/gobuffalo/buffalo/buffalo
 ```
 
 <%= title("Generating a New Project") %>


### PR DESCRIPTION
What: Added "go install ..." to upgrade instructions

Why: https://blog.gobuffalo.io/buffalo-v0-9-4-released-5d2327a4742e "how to section" says to , but getting-started.md doesnt. 