### PR TITLE
Fix example in db/callbacks

### DIFF
--- a/templates/docs/db/callbacks.md
+++ b/templates/docs/db/callbacks.md
@@ -9,7 +9,7 @@ type User struct {
   Password string
 }
 
-func (u *User) BeforeSave(tx *pop.Connection) error {
+func (u *User) BeforeCreate(tx *pop.Connection) error {
   hash, err := bcrypt.GenerateFromPassword([]byte(u.Password), bcrypt.DefaultCost)
   if err != nil {
     return errors.WithStack(err)
@@ -21,7 +21,7 @@ func (u *User) BeforeSave(tx *pop.Connection) error {
 }
 ```
 
-In the above example, when the connection's `Save` method is called with a `User`, the `BeforeSave` method
+In the above example, when the connection's `Save` method is called with a `User`, the `BeforeCreate` method
 will be called before writing to the database. The available callbacks include:
 
 * BeforeSave


### PR DESCRIPTION
Probably want to use `BeforeCreate` instead of `BeforeSave`, otherwise the password gets rehashed on every save.

```go
func (ms *ModelSuite) Test_User_BCrypt_Password_BeforeSave() {
    user := &models.User{
        Password: "password",
    }

    ms.DB.Create(user)
    bcrypted_password := user.Password
    ms.DB.Save(user)
    ms.Equal(bcrypted_password, user.Password)
}

    --- FAIL: Test_ModelSuite/Test_User_BCrypt_Password (0.25s)
        Error Trace:    user_test.go:59
        Error:          Not equal:
                        expected: "$2a$10$CgwAR8gn0GAjb7SqrNn7Ouprf5w2iQWJtoiGSSaN.EgyxtG1xOZi6"
                        actual: "$2a$10$9YMnaBR.DsILPkH1GUbG1.5ceW42v4MVYcgoyJNF.xofaMx38WPeS"
```

I know its just an example but it'll save copy-pasta people like me a few minutes of head scratching. Thanks for all the work on this project!