### PR TITLE
 helpers.md: contentFor/contentOf explanation

### DIFF
--- a/templates/docs/helpers.md
+++ b/templates/docs/helpers.md
@@ -33,20 +33,62 @@ Plush also imports all of the helpers found [https://github.com/markbates/inflec
 
 Plush ships with two complimentary helpers that let you create dynamic HTML snippets and re-use them later in the template.
 
-### The `contentFor` Helper
+### The `contentFor` and `contentOf` Helpers
 
-The `contentFor` helper takes a block of HTML and holds on to using the given name. Take the following example. We want to set up a group of buttons to be displayed at the top and bottom of a form. Using the `contentFor` helper we can store that HTML in the template under the name `buttons`.
+The `contentFor` helper takes a block of HTML and holds on to it using the given name. This block can then be used elsewhere in a template file, even when the content defined in a `contentFor` block is in a yielded-to template and is expanded into a `contentOf` block in a `yield`-calling template. The default `templates/application.html` calls `yield` like this.
+
+Take the following example. Suppose we have a `templates/application.html` that fully specifies everything in `<head>` and the outermost contents of `<body>`. This template yields to other subtemplates, like `templates/users/show.html`, to fill `<body>`. However, if we want to add or override something in the `<head>` from a subtemplate, we'll need to use `contentFor`. In this example, we'll add a way for subtemplates to add an extra chunk of CSS to the `<head>` of `application.html`:
 
 ```html
-\<% contentFor("buttons") { %>
-  &lt;button>Save&lt;/button>&lt;button>Cancel&lt;/button>
+&lt;!DOCTYPE html>
+&lt;html>
+  &lt;head>
+    &lt;meta charset="utf-8">
+    &lt;title>My Site&lt;/title>
+    \<%= stylesheetTag("application.css") %>
+    \<%= contentOf("extraStyle") %>
+  &lt;/head>
+  &lt;body>
+    &lt;div class="container">
+      \<%= partial("flash.html") %>
+      \<%= yield %>
+    &lt;/div>
+  &lt;/body>
+&lt;/html>
+```
+
+As it turns out, our `users/index.html` template could use a little page-wide styling instead of adding a bunch of `style` attributes to different elements, so it defines a block of CSS that doesn't show up anywhere inside the template:
+
+```html
+&lt;div class="page-header">
+  &lt;h1>Users&lt;/h1>
+&lt;/div>
+&lt;table class="table table-striped">
+  &lt;thead>
+    &lt;th>Username&lt;/th> &lt;th>Password&lt;/th> &lt;th>Email&lt;/th> &lt;th>Admin?&lt;/th> &lt;th>&nbsp;&lt;/th>
+  &lt;/thead>
+  &lt;tbody>
+    \<%= for (user) in users { %>
+      &lt;!-- … -->
+    \<% } %>
+  &lt;/tbody>
+&lt;/table>
+
+\<% contentFor("extraStyle") %>
+&lt;style>
+    .online {
+        color: limegreen;
+        background: black;
+    }
+    
+    .offline {
+        color: lightgray;
+        background: darkgray;
+    }
+&lt;/style>
 \<% } %>
 ```
 
-### The `contentOf` Helper
+The styling for the `online` and `offline` classes then appears at the end of `<head>` in `/users`. In other pages, nothing is added.
 
-To retrieve the content stored as `buttons`, we can use the `contentOf` helper:
-
-```html
-\<%= contentOf("buttons") %>
-```
+Of course, if you'd rather do extensive processing on what goes into a chunk that goes on a webpage, you may want to do your processing in Go code instead of in templates. In that case, call, say, `c.Set("moonPhase", mp)` where `c` is a `buffalo.Context` in a function in an action like in `actions/users.go`, and `mp` is some string or object. Then, in your templates, refer to `<%= moonPhase %>` to display your expertly-calculated phase of the moon.

--- a/templates/docs/helpers.md
+++ b/templates/docs/helpers.md
@@ -37,7 +37,7 @@ Plush ships with two complimentary helpers that let you create dynamic HTML snip
 
 The `contentFor` helper takes a block of HTML and holds on to it using the given name. This block can then be used elsewhere in a template file, even when the content defined in a `contentFor` block is in a yielded-to template and is expanded into a `contentOf` block in a `yield`-calling template. The default `templates/application.html` calls `yield` like this.
 
-Take the following example. Suppose we have a `templates/application.html` that fully specifies everything in `<head>` and the outermost contents of `<body>`. This template yields to other subtemplates, like `templates/users/show.html`, to fill `<body>`. However, if we want to add or override something in the `<head>` from a subtemplate, we'll need to use `contentFor`. In this example, we'll add a way for subtemplates to add an extra chunk of CSS to the `<head>` of `application.html`:
+Take the following example. Suppose we have a `templates/application.html` that fully specifies everything in `&lt;head>` and the outermost contents of `&lt;body>`. This template yields to other subtemplates, like `templates/users/show.html`, to fill `&lt;body>`. However, if we want to add or override something in the `&lt;head>` from a subtemplate, we'll need to use `contentFor`. In this example, we'll add a way for subtemplates to add an extra chunk of CSS to the `&lt;head>` of `application.html`:
 
 ```html
 &lt;!DOCTYPE html>
@@ -89,6 +89,7 @@ As it turns out, our `users/index.html` template could use a little page-wide st
 \<% } %>
 ```
 
-The styling for the `online` and `offline` classes then appears at the end of `<head>` in `/users`. In other pages, nothing is added.
+The styling for the `online` and `offline` classes then appears at the end of `&lt;head>` in `/users`. In other pages, nothing is added.
 
-Of course, if you'd rather do extensive processing on what goes into a chunk that goes on a webpage, you may want to do your processing in Go code instead of in templates. In that case, call, say, `c.Set("moonPhase", mp)` where `c` is a `buffalo.Context` in a function in an action like in `actions/users.go`, and `mp` is some string or object. Then, in your templates, refer to `<%= moonPhase %>` to display your expertly-calculated phase of the moon.
+Of course, if you'd rather do extensive processing on what goes into a chunk that goes on a webpage, you may want to do your processing in Go code instead of in templates. In that case, call, say, `c.Set("moonPhase", mp)` where `c` is a `buffalo.Context` in a function in an action like in `actions/users.go`, and `mp` is some string or object. Then, in your templates, refer to `\<%= moonPhase %>` to display your expertly-calculated phase of the moon.
+


### PR DESCRIPTION
This change explains that `contentFor`/`contentOf` works across `yield` boundaries and reminds new users that `func (buffalo.Context) Set(string, interface{})` may be a better option depending on the use case.