### PR TITLE
fixing javascriptTag typo in asset tagging

### DIFF
--- a/templates/docs/assets.md
+++ b/templates/docs/assets.md
@@ -54,7 +54,7 @@ By default new applications are setup to fingerprint only JavaScript and CSS fil
 With the introduction of asset fingerprinting in `v0.9.5` it became difficult to find asset files because the name of the file kept changing. To help with this, three new helpers were introduced.
 
 1. `assetPath` - This helper will return the path of the requested asset. For example, `&lt;%= assetPath("application.js") %>` would return something like `/assets/application.a8adff90f4c6d47529c4.js`.
-1. `javscriptTag` - This helper will generate a `&lt;script src="xxx">&lt;/script>` style tag for the requested JavaScript file. Example: `&lt;%= javscriptTag("application.js") %>` would return something like `&lt;script src="/assets/application.bd76587ded82386f388f.js" type="text/javascript">&lt;/script>`
+1. `javascriptTag` - This helper will generate a `&lt;script src="xxx">&lt;/script>` style tag for the requested JavaScript file. Example: `&lt;%= javascriptTag("application.js") %>` would return something like `&lt;script src="/assets/application.bd76587ded82386f388f.js" type="text/javascript">&lt;/script>`
 1. `stylesheetTag` - This helper will generate a `&lt;link href="xxx">` style tag for the requested CSS file. Example: `&lt;%= stylesheetTag("application.css") %>` would return something like `&lt;link href="/assets/application.bd76587ded82386f388f.css" media="screen" rel="stylesheet" />`
 
 <%= title("Building Assets in Development") %>


### PR DESCRIPTION
fixing a typo in templates/docs/assets.md for "javascriptTag"