### PR TITLE
simple typo fix on directory-structure

### DIFF
--- a/templates/docs/directory-structure.md
+++ b/templates/docs/directory-structure.md
@@ -9,7 +9,7 @@ Now that you have a minimal new project, let's go through its contents.
 
 <%= title("The root directory") %>
 
-Here is the strcture of a Buffalo project:
+Here is the structure of a Buffalo project:
 
 * `go/` &mdash; GOPATH root.
 	* `src/` &mdash; Go sources directory


### PR DESCRIPTION
What: Missing 'u' for 'strcture'.
Fix: added 'u'.

![u're welcome](https://thumbs.gfycat.com/ThinWeeklyDogwoodclubgall-size_restricted.gif)