### PR TITLE
Fix import path for redigo

### DIFF
--- a/templates/docs/workers.md
+++ b/templates/docs/workers.md
@@ -68,7 +68,7 @@ When setting up your application you *can* assign a worker implementation to the
 
 ```go
 import "github.com/gobuffalo/gocraft-work-adapter"
-import "github.com/garyburd/redigo/redis"
+import "github.com/gomodule/redigo/redis"
 
 // ...
 


### PR DESCRIPTION
Update import path after it has been migrated in https://github.com/gobuffalo/gocraft-work-adapter/pull/2 