### PR TITLE
Fix broken links to environment variables

### DIFF
--- a/templates/docs/_dev.fr.md
+++ b/templates/docs/_dev.fr.md
@@ -27,4 +27,4 @@ Il arrive souvent que vous ayez déjà une application utilisant le port 3000. V
 $ PORT=3001 buffalo dev
 ```
 
-Vous pouvez également consulter le chapitre sur les [variables d'environnement](/docs/env-vars) pour plus d'informations sur la configuration de Buffalo.
+Vous pouvez également consulter le chapitre sur les [variables d'environnement](/fr/docs/config-vars) pour plus d'informations sur la configuration de Buffalo.

--- a/templates/docs/_dev.md
+++ b/templates/docs/_dev.md
@@ -27,4 +27,4 @@ Sometimes you will already have an app working on the 3000 port. You can configu
 $ PORT=3001 buffalo dev
 ```
 
-You can also take a look at the [Env Variables](/docs/env-vars) chapter for further information on Buffalo configuration.
+You can also take a look at the [Env Variables](/en/docs/config-vars) chapter for further information on Buffalo configuration.

--- a/templates/docs/deploy/systemd.fr.md
+++ b/templates/docs/deploy/systemd.fr.md
@@ -61,7 +61,7 @@ WantedBy=multi-user.target
 
 <%= title("Déclarer les variables d'environment") %>
 
-La manière officielle de gérer la configuration avec Buffalo est à travers les [variables d'environment](/docs/env-vars). En utilisant Systemd, vous pouvez les définir avec un fichier de surcharge.
+La manière officielle de gérer la configuration avec Buffalo est à travers les [variables d'environment](/fr/docs/config-vars). En utilisant Systemd, vous pouvez les définir avec un fichier de surcharge.
 
 Notre fichier de surcharge est situé dans  `/etc/systemd/system/myapp.service.d/`, et se nomme `override.conf`.
 

--- a/templates/docs/deploy/systemd.md
+++ b/templates/docs/deploy/systemd.md
@@ -61,7 +61,7 @@ WantedBy=multi-user.target
 
 <%= title("Set env variables") %>
 
-The official way to handle config with Buffalo is through [environment variables](/docs/env-vars). Using Systemd, you can set them with an override file.
+The official way to handle config with Buffalo is through [environment variables](/en/docs/config-vars). Using Systemd, you can set them with an override file.
 
 Our override file will be located in `/etc/systemd/system/myapp.service.d/`, and be called `override.conf`.
 


### PR DESCRIPTION
There were redirects, but they got dropped: https://github.com/gobuffalo/gobuffalo/pull/278/files#diff-c1ebdbddf205da1687721a8acd29043cL63

The links lead to an 404 at the moment: https://gobuffalo.io/docs/env-vars/