### PR TITLE
Add releases through v0.12.6

### DIFF
--- a/templates/docs/releases.md
+++ b/templates/docs/releases.md
@@ -6,6 +6,8 @@
 
 | <%= t("releases.date") %> | <%= t("releases.version") %> | <%= t("releases.blog") %>                                            | <%= t("releases.github") %>       |
 | ------------------------- | ---------------------------- | ------------------------------------------------------------------   | --------------------------------- |
+| August 14th, 2018         | v0.12.6                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.6") %>   |
+| August 14th, 2018         | v0.12.5                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.5") %>   |
 | July 19th, 2018           | v0.12.4                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.4") %>   |
 | June 27th, 2018           | v0.12.3                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.3") %>   |
 | June 22th, 2018           | v0.12.1                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.1") %>   |


### PR DESCRIPTION
I didn't see any blog post newer than the one linked
that was regarding releases, so left that in for v0.12.5
and v0.12.6.