### PR TITLE
Fix footer styling

### DIFF
--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -63,8 +63,13 @@ h2 {
   padding-bottom: 0.8em;
   border-radius: 0;
   margin-bottom: 0;
-  margin-left: -15px;
   margin-right: -15px;
+}
+
+@media screen and (max-width: 767px) {
+  #global-footer {
+    margin-left: -15px;
+  }
 }
 
 .feature {

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -1,6 +1,6 @@
 <!-- Footer -->
 <footer id="global-footer">
-  <div class="container">
+  <div class="container-fluid">
     <div class="row">
       <div class="col-md-7 col-sm-6">
         <p><%= raw(t("footer.copyright", {year: year})) %></p>


### PR DESCRIPTION
You were able to scroll the footer over a bit and the copyright
would bleed into the sidebar.

- Changed footer interior `container` to `container-fluid`
- Moved `margin-left: -15px;` to smaller screen to account for the container change

**Original large and small screens**
<img width="1503" alt="orig" src="https://user-images.githubusercontent.com/3457341/44698426-13fee900-aa3d-11e8-9670-e79995e18433.png">

<img width="447" alt="orig_small" src="https://user-images.githubusercontent.com/3457341/44698429-182b0680-aa3d-11e8-8d99-f760a0133d11.png">

**Updated large and small screens**
<img width="1503" alt="new" src="https://user-images.githubusercontent.com/3457341/44698465-40b30080-aa3d-11e8-91d0-6a2be0f2f0e5.png">

<img width="447" alt="new_small" src="https://user-images.githubusercontent.com/3457341/44698468-44468780-aa3d-11e8-8768-da17b3b0de9f.png">
