### PR TITLE
Link to the releases in the overview

### DIFF
--- a/templates/overview.fr.html
+++ b/templates/overview.fr.html
@@ -8,7 +8,7 @@
         <a href="/fr/docs/installation" class="btn btn-primary btn-lg">Démarrer</a>
       </p>
       <p>
-        Dernière version&nbsp;: <a href="https://github.com/gobuffalo/buffalo/releases" target="_blank"><strong><%= version %></strong></a><br />
+        Dernière version&nbsp;: <a href="https://github.com/gobuffalo/buffalo/releases/tag/v<%= version %>" target="_blank"><strong><%= version %></strong></a><br />
         Nécessite Go <strong><%= goMinVersion %>+</strong>
       </p>
     </div>

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -8,7 +8,7 @@
         <a href="/en/docs/installation" class="btn btn-primary btn-lg">Get started</a>
       </p>
       <p>
-        Latest release: <a href="https://github.com/gobuffalo/buffalo/releases" target="_blank"><strong><%= version %></strong></a><br />
+        Latest release: <a href="https://github.com/gobuffalo/buffalo/releases/tag/v<%= version %>" target="_blank"><strong><%= version %></strong></a><br />
         Requires Go <strong><%= goMinVersion %>+</strong>
       </p>
     </div>
@@ -136,4 +136,3 @@
 <h2>Discover Buffalo on video</h2>
 
 <%= partial("docs/youtube.html") %>
-


### PR DESCRIPTION
This is a simple change that links to the release in the overview on the homepage.