### PR TITLE
Fix spelling, grammar and formatting errors

### DIFF
--- a/templates/docs/cookies.md
+++ b/templates/docs/cookies.md
@@ -3,7 +3,7 @@
 
 <%= h1("Cookies") %>
 
-An HTTP cookie is a small piece of data that a server sends to the user's web brower. The browser can store this data and send it back to the same server, even after the browser restart (unlike a [browser session](/en/docs/sessions)).
+An HTTP cookie is a small piece of data that a server sends to the user's web browser. The browser can store this data and send it back to the same server, even after the browser restart (unlike a [browser session](/en/docs/sessions)).
 
 (HTTP) cookies are commonly used to save users state (like whether the user logged-in). See [https://golang.org/pkg/net/http/#Cookie](https://golang.org/pkg/net/http/#Cookie) for more information on cookies in Go.
 

--- a/templates/docs/db/relations.md
+++ b/templates/docs/db/relations.md
@@ -1,4 +1,4 @@
-# Assocations and Relationships
+# Associations and Relationships
 
 Pop allows you to perform an eager loading for associations defined in a model. By using [`pop.Connection.Eager()`](https://godoc.org/github.com/gobuffalo/pop#Connection.Eager) method plus some struct field tags predefined in your model you can extract associated data from a model.
 
@@ -59,7 +59,7 @@ u := Users{}
 err := tx.Eager().Where("name = 'Mark'").All(&u)  // preload all associations for user with name 'Mark', i.e Books, Houses and FavoriteSong
 ```
 
-By default `Eager` will load all the assigned assocations for the model. To specify which associations should be loaded you can pass in the names of those fields to the `Eager` method and only those associations will be loaded.
+By default `Eager` will load all the assigned associations for the model. To specify which associations should be loaded you can pass in the names of those fields to the `Eager` method and only those associations will be loaded.
 
 ```go
 err  = tx.Eager("Books").Where("name = 'Mark'").All(&u) // preload only Books association for user with name 'Mark'.
@@ -74,4 +74,4 @@ tx.Load(u) // load all associations for user, i.e Books, Houses and FavoriteSong
 tx.Load(u, "Books") // load only the Books associations for user
 ```
 
-The `Load` method will not retreive the `User` from the database only its associations.
+The `Load` method will not retrieve the `User` from the database only its associations.

--- a/templates/docs/db/toolbox.md
+++ b/templates/docs/db/toolbox.md
@@ -6,7 +6,7 @@
 Pop helps you to manage database connections, but it also provides `soda`, a small CLI toolbox to manage your database. It can help you to create a new database, drop existing ones, and so on.
 
 <%= note() { %>
-**Note for Buffalo users**: `soda` commands are embedded into the `buffalo` command, behind the `db` namespace. So everytime you want to use a command from `soda`, just execute `buffalo db` instead. You don't need to install `soda` CLI.
+**Note for Buffalo users**: `soda` commands are embedded into the `buffalo` command, behind the `db` namespace. So every time you want to use a command from `soda`, just execute `buffalo db` instead. You don't need to install `soda` CLI.
 <% } %>
 
 <%= title("Installing CLI Support") %>

--- a/templates/docs/errors.md
+++ b/templates/docs/errors.md
@@ -6,7 +6,7 @@
 func MyHandler(c buffalo.Context) error {
   // Return any old error, this will result in a 500 status code.
   return errors.New("boom!")
-  }
+}
 ```
 
 ```go

--- a/templates/docs/helpers.md
+++ b/templates/docs/helpers.md
@@ -68,7 +68,7 @@ api := app.Group("/api/v1")
 api.Resource("/users", UsersResource{})
 ```
 
-**Note** that the helpers are generated to match the generated paths. It is possible to override the path names in the `App.Routes`, but it is highly adviced that you find a different way to your goal than this. Slack is always open to these conversations.
+**Note** that the helpers are generated to match the generated paths. It is possible to override the path names in the `App.Routes`, but it is highly advised that you find a different way to your goal than this. Slack is always open to these conversations.
 
 <%= title("Content Helpers") %>
 

--- a/templates/docs/localization.md
+++ b/templates/docs/localization.md
@@ -46,7 +46,7 @@ The second arg is accessible as "Count" in the translations strings.
 
 <%= title("Provide translations") %>
 
-Translations are stored in the `locales` folder. By default, they are stored in a `all.en-us.yaml` file for the american english strings.
+Translations are stored in the `locales` folder. By default, they are stored in a `all.en-us.yaml` file for the American English strings.
 
 You can provide translations for another language by providing a new file `all.my-language-code.yaml`. If you want to split your strings into logical modules, you can even create multiples files, e.g. `users.en-us.yaml` for the user-related stuff, and `all.en-us.yaml` for the global stuff.
 

--- a/templates/docs/new-project.md
+++ b/templates/docs/new-project.md
@@ -37,7 +37,7 @@ You can get the available flags list using the `help` command:
 
 <%= partial("docs/new-project/help.md") %>
 
-You can choose to generate an API application, skipping the frontend stuff. Maybe you want to setup a CI to build your app on your favourite system? Or even use your own package to handle the database? Just use the flags!
+You can choose to generate an API application, skipping the frontend stuff. Maybe you want to setup a CI to build your app on your favorite system? Or even use your own package to handle the database? Just use the flags!
 
 <%= title("Override Default Config") %>
 

--- a/templates/docs/releases.md
+++ b/templates/docs/releases.md
@@ -10,7 +10,7 @@
 | August 14th, 2018         | v0.12.5                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.5") %>   |
 | July 19th, 2018           | v0.12.4                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.4") %>   |
 | June 27th, 2018           | v0.12.3                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.3") %>   |
-| June 22th, 2018           | v0.12.1                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.1") %>   |
+| June 22nd, 2018           | v0.12.1                      | https://blog.gobuffalo.io/buffalo-v0-12-1-patch-release-929dda0a197f | <%= githubRelease("v0.12.1") %>   |
 | June 12th, 2018           | v0.12.0                      | https://blog.gobuffalo.io/buffalo-v0-12-0-released-c8412c7198f0      | <%= githubRelease("v0.12.0") %>   |
 | May 2nd, 2018             | v0.11.1                      | https://blog.gobuffalo.io/buffalo-v0-11-1-patch-release-7cca1d415f7  | <%= githubRelease("v0.11.1") %>   |
 | February 28th, 2018       | v0.11.0                      | https://blog.gobuffalo.io/buffalo-v0-11-0-released-f7f79be826ff      | <%= githubRelease("v0.11.0") %>   |

--- a/templates/docs/sessions.md
+++ b/templates/docs/sessions.md
@@ -2,7 +2,7 @@
 <% seoKeywords(["buffalo", "go", "golang", "http", "session"]) %>
 
 <%= h1("Sessions") %>
-An HTTP session is a non-persistant data storage, which is destroyed on browser shutdown (in the default browser configuration). It can be used to store flash messages, or any temporary user-specific data. Use [cookies](/en/docs/cookies) instead if you need a more persistant client side storage.
+An HTTP session is a non-persistent data storage, which is destroyed on browser shutdown (in the default browser configuration). It can be used to store flash messages, or any temporary user-specific data. Use [cookies](/en/docs/cookies) instead if you need a more persistent client side storage.
 
 The session is available directly from the `buffalo.Context` inside of a handler.
 


### PR DESCRIPTION
Fixes for a few spelling, grammar and formatting errors.

`favourite` -> `favorite` may not have been necessary, but `favorite` is used in other places in the docs. 