### PR TITLE
Update workers.md

### DIFF
--- a/templates/docs/workers.md
+++ b/templates/docs/workers.md
@@ -110,7 +110,7 @@ import "github.com/gobuffalo/buffalo/worker"
 var w worker.Worker
 
 func init() {
-  w = app.Worker // Get a ref to the previously defined Worker
+  w = App().Worker // Get a ref to the previously defined Worker
   w.Register("send_email", func(args worker.Args) error {
     // do work to send an email
     return nil


### PR DESCRIPTION
If you assign the ref of the pre-defined Worker to the variable `w` you'll get 

```
runtime error: invalid memory address or nil pointer dereference
```

I've fixed this issue by assigning the `App()` function instead.