### PR TITLE
Update MacOS instructions to use curl

### DIFF
--- a/templates/docs/installation.md
+++ b/templates/docs/installation.md
@@ -46,7 +46,7 @@ Since `v0.10.3`, pre-compiled archives are provided with each release. If you do
 ### GNU / Linux
 
 ```bash
-$ wget  https://github.com/gobuffalo/buffalo/releases/download/v<%= version %>/buffalo_<%= version %>_linux_amd64.tar.gz
+$ wget https://github.com/gobuffalo/buffalo/releases/download/v<%= version %>/buffalo_<%= version %>_linux_amd64.tar.gz
 $ tar -xvzf buffalo_<%= version %>_linux_amd64.tar.gz
 $ sudo mv buffalo-no-sqlite /usr/local/bin/buffalo
 ```
@@ -54,7 +54,7 @@ $ sudo mv buffalo-no-sqlite /usr/local/bin/buffalo
 ### MacOS
 
 ```bash
-$ wget  https://github.com/gobuffalo/buffalo/releases/download/v<%= version %>/buffalo_<%= version %>_darwin_amd64.tar.gz
+$ curl -OL https://github.com/gobuffalo/buffalo/releases/download/v<%= version %>/buffalo_<%= version %>_darwin_amd64.tar.gz
 $ tar -xvzf buffalo_<%= version %>_darwin_amd64.tar.gz
 $ sudo mv buffalo-no-sqlite /usr/local/bin/buffalo
 # or if you have ~/bin folder setup in the environment PATH variable


### PR DESCRIPTION
wget does not come with macOS by default.