### PR TITLE
Add paragraph for bash tooling integration

### DIFF
--- a/templates/docs/integrations.md
+++ b/templates/docs/integrations.md
@@ -9,6 +9,10 @@ You can work with Buffalo using your preferred tools. Here is a list of contribu
 
 If you use `zsh` shell, you can use this plugin, created by [@1995parham](https://github.com/1995parham): https://github.com/1995parham/buffalo.zsh
 
+<%= title("bash autocomplete") %>
+
+If you use `bash` shell, you can try this script, created by [@cippaciong](https://github.com/cippaciong), which provides basic autocompletion: https://github.com/cippaciong/buffalo_bash_completion
+
 <%= title("Next Steps") %>
 
 * [Generate a New Project](/en/docs/new-project) - Create your first Buffalo project!


### PR DESCRIPTION
Hello, since I made a basic bash completion script for buffalo, I added the relative paragraph in tooling integration to point to my repository with the script and installation instructions.