### PR TITLE
Point readers to custom rendering if they need to render a JSON or XML string

### DIFF
--- a/templates/docs/rendering/_func.md
+++ b/templates/docs/rendering/_func.md
@@ -18,8 +18,9 @@ func csvWriter(w io.Writer, d render.Data) error {
 ```
 
 For smaller, or one off situations, using an anonymous function can be even easier. 
-
+In this example you can see how to use an anonymous function to render a string that already contains JSON.
 ```go
+var myJSONString string
 return c.Render(200, r.Func("application/json", func(w io.Writer, d render.Data) error {
 	_, err := w.Write([]byte(myJSONString))
 	return err

--- a/templates/docs/rendering/_json.md
+++ b/templates/docs/rendering/_json.md
@@ -3,7 +3,7 @@
 When rendering JSON, or XML, using the [`r.JSON`](https://godoc.org/github.com/gobuffalo/buffalo/render#JSON) or [`r.XML`](https://godoc.org/github.com/gobuffalo/buffalo/render#XML), you pass the value that you would like to be marshaled and the appropriate marshaler will encode the value you passed and write it to the response with the correct content/type.
 
 **NOTE**: If you already have a string that contains JSON or XML do **NOT** use these methods as they will attempt to marshal the string into JSON or XML causing strange responses.
-
+What you could do instead is write a custom render function as explained in the [Custom Rendering](rendering#custom-rendering) section.
 ```go
 func MyHandler(c buffalo.Context) error {
   return c.Render(200, r.JSON(User{}))


### PR DESCRIPTION
As discussed with @markbates on Slack, it would be nice to point users to custom rendering if they need to render a string which is already marshalled in JSON/XML instead of simply telling them not to use `r.JSON()` or `r.XML()`.
I also added a declaration for `var myJSONString string` in the code example because I think it helps newcomers to better understand the example (it did for me at least :smile:), but I can remove it if you don't like it.