### PR TITLE
Fix Typo on worker.md

### DIFF
--- a/templates/docs/workers.md
+++ b/templates/docs/workers.md
@@ -161,13 +161,13 @@ func doWork() {
 
 #### `worker.PerformAt`
 
-The `PerformIn` method enqueues the job, so the worker should try and run the job at (or near) the time specified, based on the implementation of the worker itself.
+The `PerformAt` method enqueues the job, so the worker should try and run the job at (or near) the time specified, based on the implementation of the worker itself.
 
 ```go
 func doWork() {
   // Send the send_email job to the queue, and process it at now + 5 seconds.
   // Please note if no working unit is free at this time, it will wait for a free slot.
-  w.PerformIn(worker.Job{
+  w.PerformAt(worker.Job{
     Queue: "default",
     Handler: "send_email",
     Args: worker.Args{


### PR DESCRIPTION
Earlier: `PerformAt` had typo as `PerformIn` in **worker.PerformAt** description and example section.
![screenshot-20190131-11 58 47](https://user-images.githubusercontent.com/1695906/52034129-a016be80-254f-11e9-8c37-752338a4e226.png)
