### PR TITLE
Update errors.md

### DIFF
--- a/templates/docs/errors.md
+++ b/templates/docs/errors.md
@@ -74,7 +74,7 @@ app = buffalo.New(buffalo.Options{
 app.ErrorHandlers[422] = func(status int, err error, c buffalo.Context) error {
   res := c.Response()
   res.WriteHeader(422)
-  res.Write([]byte(fmt.Sprintf("Oops!! There was an error %s", err.Error())))
+  res.Write([]byte(fmt.Sprintf("Oops!! There was an error: %s", err.Error())))
   return nil
 }
 
@@ -86,7 +86,7 @@ func MyHandler(c buffalo.Context) error {
 ```
 
 ```text
-GET /oops -> [422] Oh no!
+GET /oops -> [422] Oops!! There was an error: Oh no!
 ```
 
 In the above example any error from your application that returns a status of `422` will be caught by the custom handler and will be dealt with accordingly.


### PR DESCRIPTION
i think this is what was meant..
The custom error handler kicks in and has access to the original error message.

![image](https://user-images.githubusercontent.com/11358371/52973271-d3d35e80-3400-11e9-916b-622062a55366.png)

In the screenshot above, I think the actual response should be `Oops!! There was an error Oh no!` rather than just `Oh no!`