### PR TITLE
Fix unintended overflow

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -1,33 +1,32 @@
 <!-- Footer -->
 <footer id="global-footer">
-  <div class="container">
-    <div class="container-fluid">
-      <div class="row">
-        <div class="col-md-7 col-sm-6">
-          <p><strong><%= raw(t("footer.copyright", {year: year})) %></strong></p>
-          <p>
-            <%= raw(t("footer.gopher")) %>
-          </p>
-        </div>
-        <div class="col-md-5 col-sm-6">
-          <ul class="footer-menu">
-            <li>
-              <a href="https://travis-ci.org/gobuffalo/buffalo" target="_blank" rel="noopener noreferrer">
-                <img src="https://travis-ci.org/gobuffalo/buffalo.svg?branch=master" alt="Build Status" />
-              </a>
-            </li>
-            <li>
-              <a href="https://goreportcard.com/report/github.com/gobuffalo/buffalo" target="_blank" rel="noopener noreferrer">
-                <img src="https://goreportcard.com/badge/github.com/gobuffalo/buffalo" alt="Go Report Card" />
-              </a>
-            </li>
-            <li>
-              <a href="https://www.codetriage.com/gobuffalo/buffalo" target="_blank" rel="noopener noreferrer">
-                <img src="https://www.codetriage.com/gobuffalo/buffalo/badges/users.svg" alt="Open Source Helpers" />
-              </a>
-            </li>
-          </ul>
-        </div>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-7 col-sm-6">
+        <p><strong>
+            <%= raw(t("footer.copyright", {year: year})) %></strong></p>
+        <p>
+          <%= raw(t("footer.gopher")) %>
+        </p>
+      </div>
+      <div class="col-md-5 col-sm-6">
+        <ul class="footer-menu">
+          <li>
+            <a href="https://travis-ci.org/gobuffalo/buffalo" target="_blank" rel="noopener noreferrer">
+              <img src="https://travis-ci.org/gobuffalo/buffalo.svg?branch=master" alt="Build Status" />
+            </a>
+          </li>
+          <li>
+            <a href="https://goreportcard.com/report/github.com/gobuffalo/buffalo" target="_blank" rel="noopener noreferrer">
+              <img src="https://goreportcard.com/badge/github.com/gobuffalo/buffalo" alt="Go Report Card" />
+            </a>
+          </li>
+          <li>
+            <a href="https://www.codetriage.com/gobuffalo/buffalo" target="_blank" rel="noopener noreferrer">
+              <img src="https://www.codetriage.com/gobuffalo/buffalo/badges/users.svg" alt="Open Source Helpers" />
+            </a>
+          </li>
+        </ul>
       </div>
     </div>
   </div>


### PR DESCRIPTION
You can observe an unintended overflow in the footer of https://gobuffalo.io/en/docs/directory-structure/

### Before

![image](https://user-images.githubusercontent.com/7039523/53785685-64249f80-3ee7-11e9-910b-7bc671925852.png)

### After

![image](https://user-images.githubusercontent.com/7039523/53785742-89191280-3ee7-11e9-83c6-7eafbd054a5d.png)

### Description

Removes unnecessary `.container` from `footer`.
