### PR TITLE
Clarify required packages to range over parameters in a function handler

### DIFF
--- a/templates/docs/context.md
+++ b/templates/docs/context.md
@@ -90,6 +90,8 @@ func App() *buffalo.App {
 The `buffalo.Context#Params` method returns [`buffalo.ParamValues`](https://godoc.org/github.com/gobuffalo/buffalo#ParamValues) which is an interface around [`url.Values`](https://golang.org/pkg/net/url/#Values). You can cast to this type in a handler to range over the parameter values.
 
 ```go
+import "net/url"
+
 func HomeHandler(c buffalo.Context) error {
   if m, ok := c.Params().(url.Values); ok {
     for k, v := range m {


### PR DESCRIPTION
Related to this issue:
https://github.com/gobuffalo/gobuffalo/issues/487

For a newcomer to go and buffalo, this doesn't work out of the box, it is required to import `net/url` package. 

I think it can be useful to clarify this in the documentation